### PR TITLE
Use timeouts to trigger reconnection

### DIFF
--- a/extras/debug.conf
+++ b/extras/debug.conf
@@ -20,6 +20,7 @@ multiplier = 1
 pack_limit = 12000
 
 # Reconnect if no messages are received within the specified number of seconds.
+# Set to 0 or comment out the line to disable timeouts.
 timeout = 30
 
 [logging]

--- a/extras/debug.conf
+++ b/extras/debug.conf
@@ -19,6 +19,9 @@ multiplier = 1
 # Number of records to save on disk at once. 12000 = 20 msg/sec * 60 * 10 min
 pack_limit = 12000
 
+# Reconnect if no messages are received within the specified number of seconds.
+timeout = 30
+
 [logging]
 # Use "DEBUG" to see more messages in the console and the log-files
 log_level = INFO

--- a/extras/fake_server.py
+++ b/extras/fake_server.py
@@ -80,7 +80,7 @@ def read_cmdline():
             "Use 0 to send at a maximum possible rate."
         ),
         default=20,
-        type=int,
+        type=float,
     )
     parser.add_argument(
         "-b",

--- a/readport.py
+++ b/readport.py
@@ -159,12 +159,14 @@ def listen_device(queue, conf):
             if not data:
                 raise NoDataException("Empty data received")
         except (OSError, NoDataException) as e:
-            if isinstance(e, socket.timeout):
-                # Make the error message more specific instead of the default "timed out"
-                e = "Read timed out. No messages received in {} seconds.".format(
-                    conf.timeout
-                )
-            logging.warning(e)
+            if isinstance(e, NoDataException):
+                logging.warning(e)
+            else:
+                if isinstance(e, socket.timeout):
+                    e = "Read timed out. No messages received in {} seconds.".format(
+                        conf.timeout
+                    )
+                logging.error(e)
 
             if shutdown_event.is_set():
                 continue

--- a/readport.py
+++ b/readport.py
@@ -114,7 +114,9 @@ def connect(host, port):
                 )
                 reconnecting = True
             sock.connect((host, port))
-            logging.info("Connected. Receiving device data...".format(host, port))
+            logging.info(
+                "Connected to {}:{}. Receiving device data...".format(host, port)
+            )
             break
         except Exception:
             time.sleep(1)

--- a/readport.py
+++ b/readport.py
@@ -93,12 +93,13 @@ class Checkpoint:
             self.start_time = time.time()
 
 
-def connect(host, port, timeout):
+def connect(host, port, timeout=None):
     """Establish socket connection, retrying if necessary
 
     Args:
         host: IP address of the device
         port: port number to listen to
+        timeout: a timeout in seconds for connecting and reading data (default: None)
 
     Returns:
         sock, f: a socket handler and an associated file handler for reading line by line
@@ -325,7 +326,7 @@ def load_config(path):
         var_names=config.get("parser", "var_names").split(),
         multiplier=config.getfloat("parser", "multiplier"),
         pack_limit=config.getint("parser", "pack_limit"),
-        timeout=config.getint("parser", "timeout"),
+        timeout=config.getint("parser", "timeout", fallback=None),
         log_level=config.get("logging", "log_level"),
         log_file=config.get("logging", "log_file"),
         checkpoint_interval=config.getint("logging", "checkpoint_interval"),
@@ -341,6 +342,10 @@ def load_config(path):
             "It is reserved for the message timestamp."
         )
         sys.exit(1)
+
+    # Handle timeout=0 as None, which sets the socket in blocking mode without timeouts
+    if conf.timeout == 0:
+        conf.timeout = None
 
     return conf
 

--- a/readport_4001.conf
+++ b/readport_4001.conf
@@ -21,6 +21,10 @@ multiplier = 1
 # Number of records to save on disk at once. 12000 = 20 msg/sec * 60 * 10 min
 pack_limit = 12000
 
+# Reconnect if no messages are received within the specified number of seconds.
+# Set to 0 or comment out the line to disable timeouts.
+timeout = 0
+
 [logging]
 # Use "DEBUG" to see more messages in the console and the log-files
 log_level = INFO

--- a/readport_4002.conf
+++ b/readport_4002.conf
@@ -21,6 +21,10 @@ multiplier = 1e-2
 # Number of records to save on disk at once. 12000 = 20 msg/sec * 60 * 10 min
 pack_limit = 12000
 
+# Reconnect if no messages are received within the specified number of seconds.
+# Set to 0 or comment out the line to disable timeouts.
+timeout = 0
+
 [logging]
 # Use "DEBUG" to see more messages in the console and the log-files
 log_level = INFO

--- a/readport_4003.conf
+++ b/readport_4003.conf
@@ -21,6 +21,10 @@ multiplier = 1
 # Number of records to save on disk at once. 12000 = 20 msg/sec * 60 * 10 min
 pack_limit = 12000
 
+# Reconnect if no messages are received within the specified number of seconds.
+# Set to 0 or comment out the line to disable timeouts.
+timeout = 0
+
 [logging]
 # Use "DEBUG" to see more messages in the console and the log-files
 log_level = INFO


### PR DESCRIPTION
When Moxa is restarted, the script may fail to read device data unless the socket connection is reestablished. The following set of changes add support for a `timeout` parameter. If no messages are received from the devices within the specified number of seconds, the script initiates a reconnect.

By default, no timeout is used to preserve the original behavior. Set it to e.g. 30 seconds to enable.