### PR TITLE
Adapt rsync to the new file saving scheme

### DIFF
--- a/send_data.sh
+++ b/send_data.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 # crontab -e -> /home/gavr/TowerMSU/send_data.sh
-for i in $(ls /home/gavr/TowerMSU/data/*.npz); do
-	rsync -a ${i} naad-tower:/public/TOWER/npz/
-	if [ "$?" -eq "0" ]; then
-  		rm -rf ${i}
-	fi
-done
+rsync -a --exclude='*.tmp' --remove-source-files /home/gavr/TowerMSU/data/ naad-tower:/public/TOWER/npz/

--- a/send_data.sh
+++ b/send_data.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 # crontab -e -> /home/gavr/TowerMSU/send_data.sh
-rsync -a --exclude='*.tmp' --remove-source-files /home/gavr/TowerMSU/data/ naad-tower:/public/TOWER/npz/
+
+SOURCE=/home/gavr/TowerMSU/data/
+DEST=naad-tower:/var/www/data/domains/tower.ocean.ru/html/flask/data/npz/
+
+rsync -a --exclude='*.tmp' --remove-source-files "$SOURCE" "$DEST"


### PR DESCRIPTION
The proposed change:

- Avoids `*.npz` wildcard expansion by bash, which may be problematic if a large number of files is present
- Makes rsync ignore `*.tmp` files that are still being written
- Asks rsync to remove the source files after they have been successfully transferred